### PR TITLE
Upgrade to swift 5 syntax

### DIFF
--- a/ios/Classes/Location/LocationClient.swift
+++ b/ios/Classes/Location/LocationClient.swift
@@ -67,7 +67,7 @@ class LocationClient : NSObject, CLLocationManagerDelegate {
   }
   
   func removeLocationUpdates(requestId: Int) {
-    guard let index = locationUpdatesRequests.index(where: { $0.id == requestId }) else {
+    guard let index = locationUpdatesRequests.firstIndex(where: { $0.id == requestId }) else {
       return
     }
     

--- a/ios/Classes/Location/LocationHelper.swift
+++ b/ios/Classes/Location/LocationHelper.swift
@@ -19,6 +19,6 @@ struct LocationHelper {
   ]
   
   static func betterAccuracy(between a1: CLLocationAccuracy, and a2: CLLocationAccuracy) -> CLLocationAccuracy {
-    return accuracies.index(of: a1)! > accuracies.index(of: a2)! ? a1 : a2
+    return accuracies.firstIndex(of: a1)! > accuracies.firstIndex(of: a2)! ? a1 : a2
   }
 }


### PR DESCRIPTION
When trying to use this package from latest xCode, it will raise an error that Swift code syntax need to be migrated/upgraded to Swift 5

It turned to be these two lines are the only needed change.
