### PR TITLE
Request new location should not fallback to last available location.

### DIFF
--- a/android/src/main/kotlin/io/alfanhui/new_geolocation/location/LocationClient.kt
+++ b/android/src/main/kotlin/io/alfanhui/new_geolocation/location/LocationClient.kt
@@ -201,19 +201,6 @@ class LocationClient(private val activity: Activity) {
                 return@launch
             }
 
-            val hasCurrentRequest = locationUpdatesRequests.any { it.strategy == LocationUpdatesRequest.Strategy.Current }
-            if (hasCurrentRequest) {
-                val lastLocationResult = lastLocationIfAvailable()
-                if (lastLocationResult != null) {
-                    onLocationUpdatesResult(lastLocationResult)
-
-                    val hasOnlyCurrentRequest = locationUpdatesRequests.all { it.strategy == LocationUpdatesRequest.Strategy.Current }
-                    if (hasOnlyCurrentRequest) {
-                        return@launch
-                    }
-                }
-            }
-
             val locationRequest = LocationRequest.create()
 
             locationRequest.priority = locationUpdatesRequests.map { it.accuracy.androidValue }


### PR DESCRIPTION
The old code was assuming that user needs last available location by default
But there is already a function to get last known location that user can call any time.

When user request for new location, The expected behavior should be always resolving new location.